### PR TITLE
Cache the creation of the HTTP client

### DIFF
--- a/core/call.go
+++ b/core/call.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"strings"
 
 	"github.com/karlseguin/typed"
@@ -13,6 +14,9 @@ import (
 func GetEndpointURI(host string, method string) string {
 	return fmt.Sprintf("%s/api/%s", strings.TrimSuffix(host, "/"), method)
 }
+
+// Global client to improve connection caching (per godoc).
+var client *http.Client
 
 // PerformCall performs a call to the Conduit API with the provided URL and
 // parameters. The response will be unmarshaled into the passed result struct.
@@ -30,7 +34,9 @@ func PerformCall(
 		return err
 	}
 
-	client := makeHTTPClient(options)
+	if client == nil {
+		client = makeHTTPClient(options)
+	}
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/core/http.go
+++ b/core/http.go
@@ -16,7 +16,8 @@ type ClientOptions struct {
 
 	InsecureSkipVerify bool
 
-	Timeout time.Duration
+	RoundTripper http.RoundTripper
+	Timeout      time.Duration
 }
 
 // makeHttpClient creates a new HTTP client for making API requests.
@@ -27,12 +28,19 @@ func makeHTTPClient(options *ClientOptions) *http.Client {
 		timeout = options.Timeout
 	}
 
-	return &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: options.InsecureSkipVerify,
-			},
+	var transport http.RoundTripper
+
+	transport = &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: options.InsecureSkipVerify,
 		},
+	}
+	if options.RoundTripper != nil {
+		transport = options.RoundTripper
+	}
+
+	return &http.Client{
+		Transport: transport,
 		Timeout: timeout,
 	}
 }

--- a/differential.go
+++ b/differential.go
@@ -6,6 +6,7 @@ import (
 )
 
 // DifferentialQuery performs a call to differential.query.
+// Deprecated: This method is frozen and will eventually be deprecated. New code should use "differential.revision.search" instead.
 func (c *Conn) DifferentialQuery(
 	req requests.DifferentialQueryRequest,
 ) (*responses.DifferentialQueryResponse, error) {
@@ -19,6 +20,7 @@ func (c *Conn) DifferentialQuery(
 }
 
 // DifferentialQueryDiffs performs a call to differential.querydiffs.
+// Deprecated: This method is frozen and will eventually be deprecated. New code should use "differential.diff.search" instead.
 func (c *Conn) DifferentialQueryDiffs(req requests.DifferentialQueryDiffsRequest) (responses.DifferentialQueryDiffsResponse, error) {
 	var res responses.DifferentialQueryDiffsResponse
 	if err := c.Call("differential.querydiffs", &req, &res); err != nil {

--- a/diffusion.go
+++ b/diffusion.go
@@ -6,6 +6,7 @@ import (
 )
 
 // DiffusionQueryCommits performs a call to diffusion.querycommits.
+// Deprecated: This method is frozen and will eventually be deprecated. New code should use "diffusion.commit.search" instead.
 func (c *Conn) DiffusionQueryCommits(
 	req requests.DiffusionQueryCommitsRequest,
 ) (*responses.DiffusionQueryCommitsResponse, error) {

--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 	github.com/onsi/gomega v1.5.0
 	github.com/stretchr/testify v1.3.0
 )
+
+go 1.13

--- a/maniphest.go
+++ b/maniphest.go
@@ -7,6 +7,7 @@ import (
 )
 
 // ManiphestQuery performs a call to maniphest.query.
+// Deprecated: This method is frozen and will eventually be deprecated. New code should use "maniphest.search" instead.
 func (c *Conn) ManiphestQuery(
 	req requests.ManiphestQueryRequest,
 ) (*responses.ManiphestQueryResponse, error) {
@@ -20,6 +21,7 @@ func (c *Conn) ManiphestQuery(
 }
 
 // ManiphestCreateTask performs a call to maniphest.createtask.
+// Deprecated: This method is frozen and will eventually be deprecated. New code should use "maniphest.edit" instead.
 func (c *Conn) ManiphestCreateTask(
 	req requests.ManiphestCreateTaskRequest,
 ) (*entities.ManiphestTask, error) {
@@ -33,6 +35,7 @@ func (c *Conn) ManiphestCreateTask(
 }
 
 // ManiphestGetTaskTransactions performs a call to maniphest.gettasktransactions
+// Deprecated: This method is frozen and will eventually be deprecated. New code should use "transaction.search" instead.
 func (c *Conn) ManiphestGetTaskTransactions(
 	req requests.ManiphestGetTaskTransactions,
 ) (*responses.ManiphestGetTaskTransactionsResponse, error) {

--- a/paste.go
+++ b/paste.go
@@ -6,6 +6,7 @@ import (
 )
 
 // PasteCreate calls the paste.create endpoint.
+// Deprecated: This method is frozen and will eventually be deprecated. New code should use "paste.edit" instead.
 func (c *Conn) PasteCreate(
 	req *requests.PasteCreateRequest,
 ) (responses.PasteCreateResponse, error) {
@@ -19,6 +20,7 @@ func (c *Conn) PasteCreate(
 }
 
 // PasteQuery calls the paste.query endpoint.
+// Deprecated: This method is frozen and will eventually be deprecated. New code should use "paste.search" instead.
 func (c *Conn) PasteQuery(
 	req *requests.PasteQueryRequest,
 ) (responses.PasteQueryResponse, error) {

--- a/phriction.go
+++ b/phriction.go
@@ -6,6 +6,7 @@ import (
 )
 
 // PhrictionInfo performs a call to phriction.info
+// Deprecated: This method is frozen and will eventually be deprecated. New code should use "phriction.document.search" instead.
 func (c *Conn) PhrictionInfo(
 	req requests.PhrictionInfoRequest,
 ) (*responses.PhrictionInfoResponse, error) {

--- a/repository.go
+++ b/repository.go
@@ -6,6 +6,7 @@ import (
 )
 
 // RepositoryQuery performs a call to repository.query.
+// Deprecated: This method is frozen and will eventually be deprecated. New code should use "diffusion.repository.search" instead.
 func (c *Conn) RepositoryQuery(
 	req requests.RepositoryQueryRequest,
 ) (*responses.RepositoryQueryResponse, error) {

--- a/user.go
+++ b/user.go
@@ -6,6 +6,7 @@ import (
 )
 
 // UserQuery performs a call to user.query.
+// Deprecated: This method is frozen and will eventually be deprecated. New code should use "user.search" instead.
 func (c *Conn) UserQuery(
 	req requests.UserQueryRequest,
 ) (*responses.UserQueryResponse, error) {


### PR DESCRIPTION
The documentation for `http.Client` suggests that the created client ought to be reused, instead of created for every call. In order to maintain the same public interface we introduce a package-level variable to hold the client, and initialise it on the first `PerformCall` invocation.

We allow the `ClientOptions` to provide an instance of the `http.RoundTripper` as well, to allow callers more control over the client.

We also add some deprecation notices for methods that should no longer be used.