### PR TITLE
Exposing maniphest subtypes

### DIFF
--- a/entities/maniphest.go
+++ b/entities/maniphest.go
@@ -28,6 +28,7 @@ type ManiphestTask struct {
 	DateModified       util.UnixTimestamp `json:"dateModified"`
 	DependsOnTaskPHIDs []string           `json:"dependsOnTaskPHIDs"`
 	Points             float64            `json:"points"`
+	Subtypes 		   string			  `json:"subtypes"`
 }
 
 type ManiphestPoints int

--- a/entities/maniphest.go
+++ b/entities/maniphest.go
@@ -28,7 +28,7 @@ type ManiphestTask struct {
 	DateModified       util.UnixTimestamp `json:"dateModified"`
 	DependsOnTaskPHIDs []string           `json:"dependsOnTaskPHIDs"`
 	Points             float64            `json:"points"`
-	Subtypes 		   string			  `json:"subtypes"`
+	Subtypes           string             `json:"subtypes"`
 }
 
 type ManiphestPoints int


### PR DESCRIPTION
Adding subtypes to the maniphest struct, so this field is accessible in the response.