### PR TITLE
Remove unused imports

### DIFF
--- a/requests/commitparentsquery.go
+++ b/requests/commitparentsquery.go
@@ -1,7 +1,5 @@
 package requests
 
-import "github.com/thought-machine/gonduit/constants"
-
 // CommitParentsQueryRequest represents a request to the diffusion.commitparentsquery endpoint.
 // One of "repository" or "callsign" is required.  Since "callsign" is deprecated we require "repository".
 type CommitParentsQueryRequest struct {

--- a/requests/resolverefs.go
+++ b/requests/resolverefs.go
@@ -1,7 +1,5 @@
 package requests
 
-import "github.com/thought-machine/gonduit/constants"
-
 // ResolveRefsRequest represents a request to the diffusion.resolverefs endpoint.
 type ResolveRefsRequest struct {
 	Refs       []string `json:"refs"`


### PR DESCRIPTION
This time I ran `go build` in the root of the repo and didn't get any warnings.