### PR TITLE
Fix ManiphestCreateTaskRequest optional fields

### DIFF
--- a/requests/maniphest_createtask.go
+++ b/requests/maniphest_createtask.go
@@ -4,11 +4,11 @@ package requests
 type ManiphestCreateTaskRequest struct {
 	Title        string                        `json:"title"`
 	Description  string                        `json:"description"`
-	OwnerPHID    string                        `json:"ownerPHID"`
-	ViewPolicy   string                        `json:"viewPolicy"`
-	EditPolicy   string                        `json:"editPolicy"`
-	CCPHIDs      []string                      `json:"ccPHIDs"`
-	Priority     int                           `json:"priority"`
-	ProjectPHIDs []string                      `json:"projectPHIDs"`
+	OwnerPHID    string                        `json:"ownerPHID,omitempty"`
+	ViewPolicy   string                        `json:"viewPolicy,omitempty"`
+	EditPolicy   string                        `json:"editPolicy,omitempty"`
+	CCPHIDs      []string                      `json:"ccPHIDs,omitempty"`
+	Priority     int                           `json:"priority,omitempty"`
+	ProjectPHIDs []string                      `json:"projectPHIDs,omitempty"`
 	Request
 }


### PR DESCRIPTION
Optional fields should be omitempty, otherwise they are interpreted
by conduit as empty values.